### PR TITLE
Adding feature - support of XChaCha20+Poly1305 algorithms for SecretBox processing

### DIFF
--- a/src/Sodium.Core/SecretBox.cs
+++ b/src/Sodium.Core/SecretBox.cs
@@ -128,7 +128,7 @@ namespace Sodium
         /// <summary>Opens a Secret Box</summary>
         /// <param name="cipherText">The cipherText.</param>
         /// <param name="nonce">The 24 byte nonce.</param>
-        /// <param name="key">The 32 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
         /// <returns>The decrypted text.</returns>
         /// <exception cref="KeyOutOfRangeException"></exception>
         /// <exception cref="NonceOutOfRangeException"></exception>
@@ -183,7 +183,7 @@ namespace Sodium
         /// <param name="cipherText">Hex-encoded string to be opened</param>
         /// <param name="mac">The 16 byte mac.</param>
         /// <param name="nonce">The 24 byte nonce.</param>
-        /// <param name="key">The 32 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
         /// <returns>The decrypted text.</returns>
         /// <exception cref="KeyOutOfRangeException"></exception>
         /// <exception cref="NonceOutOfRangeException"></exception>
@@ -197,7 +197,7 @@ namespace Sodium
         /// <summary>Opens a detached Secret Box</summary>
         /// <param name="detached">A detached object.</param>
         /// <param name="nonce">The 24 byte nonce.</param>
-        /// <param name="key">The 32 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
         /// <returns>The decrypted text.</returns>
         /// <exception cref="KeyOutOfRangeException"></exception>
         /// <exception cref="NonceOutOfRangeException"></exception>
@@ -212,7 +212,7 @@ namespace Sodium
         /// <param name="cipherText">The cipherText.</param>
         /// <param name="mac">The 16 byte mac.</param>
         /// <param name="nonce">The 24 byte nonce.</param>
-        /// <param name="key">The 32 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
         /// <returns>The decrypted text.</returns>
         /// <exception cref="KeyOutOfRangeException"></exception>
         /// <exception cref="NonceOutOfRangeException"></exception>

--- a/src/Sodium.Core/SecretBox.cs
+++ b/src/Sodium.Core/SecretBox.cs
@@ -243,5 +243,221 @@ namespace Sodium
 
             return buffer;
         }
+        
+
+
+        /// <summary>Creates a Secret Box using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="message">Hex-encoded string to be encrypted.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>The encrypted message.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static byte[] Xchacha20Poly1305Create(string message, byte[] nonce, byte[] key) =>
+            Xchacha20Poly1305Create(Encoding.UTF8.GetBytes(message), nonce, key);
+
+        /// <summary>Creates a Secret Box using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="message">The message.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>The encrypted message.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static byte[] Xchacha20Poly1305Create(byte[] message, byte[] nonce, byte[] key)
+        {
+            //validate the length of the key
+            if (key == null || key.Length != KEY_BYTES)
+                throw new KeyOutOfRangeException(nameof(key), (key == null) ? 0 : key.Length,
+                  string.Format("key must be {0} bytes in length.", KEY_BYTES));
+
+            //validate the length of the nonce
+            if (nonce == null || nonce.Length != NONCE_BYTES)
+                throw new NonceOutOfRangeException(nameof(nonce), (nonce == null) ? 0 : nonce.Length,
+                  string.Format("nonce must be {0} bytes in length.", NONCE_BYTES));
+
+            var buffer = new byte[MAC_BYTES + message.Length];
+            var ret = SodiumLibrary.crypto_secretbox_xchacha20poly1305_easy(buffer, message, message.Length, nonce, key);
+
+            if (ret != 0)
+                throw new CryptographicException("Failed to create SecretBox");
+
+            return buffer;
+        }
+
+        /// <summary>Creates detached a Secret Box using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="message">Hex-encoded string to be encrypted.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>A detached object with a cipher and a mac.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static DetachedBox Xchacha20Poly1305CreateDetached(string message, byte[] nonce, byte[] key) =>
+            Xchacha20Poly1305CreateDetached(Encoding.UTF8.GetBytes(message), nonce, key);
+
+        /// <summary>Creates detached a Secret Box using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="message">The message.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>A detached object with a cipher and a mac.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static DetachedBox Xchacha20Poly1305CreateDetached(byte[] message, byte[] nonce, byte[] key)
+        {
+            //validate the length of the key
+            if (key == null || key.Length != KEY_BYTES)
+                throw new KeyOutOfRangeException(nameof(key), (key == null) ? 0 : key.Length,
+                    $"key must be {KEY_BYTES} bytes in length.");
+
+            //validate the length of the nonce
+            if (nonce == null || nonce.Length != NONCE_BYTES)
+                throw new NonceOutOfRangeException(nameof(nonce), (nonce == null) ? 0 : nonce.Length,
+                    $"nonce must be {NONCE_BYTES} bytes in length.");
+
+            var cipher = new byte[message.Length];
+            var mac = new byte[MAC_BYTES];
+            var ret = SodiumLibrary.crypto_secretbox_xchacha20poly1305_detached(cipher, mac, message, message.Length, nonce, key);
+
+            if (ret != 0)
+                throw new CryptographicException("Failed to create detached SecretBox");
+
+            return new DetachedBox(cipher, mac);
+        }
+
+        /// <summary>Opens a Secret Box using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="cipherText">Hex-encoded string to be opened.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>The decrypted text.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static byte[] Xchacha20Poly1305Open(string cipherText, byte[] nonce, byte[] key) =>
+            Xchacha20Poly1305Open(Utilities.HexToBinary(cipherText), nonce, key);
+
+
+        /// <summary>Opens a Secret Box using using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="cipherText">The cipherText.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>The decrypted text.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static byte[] Xchacha20Poly1305Open(byte[] cipherText, byte[] nonce, byte[] key)
+        {
+            //validate the length of the key
+            if (key == null || key.Length != KEY_BYTES)
+                throw new KeyOutOfRangeException(nameof(key), (key == null) ? 0 : key.Length,
+                    $"key must be {KEY_BYTES} bytes in length.");
+
+            //validate the length of the nonce
+            if (nonce == null || nonce.Length != NONCE_BYTES)
+                throw new NonceOutOfRangeException(nameof(nonce), (nonce == null) ? 0 : nonce.Length,
+                    $"nonce must be {NONCE_BYTES} bytes in length.");
+
+            // todo - please review this! I'm not sure if this block is needed also for xchacha-version
+            {
+
+                ////check to see if there are MAC_BYTES of leading nulls, if so, trim.
+                ////this is required due to an error in older versions.
+                //if (cipherText[0] == 0)
+                //{
+                //    //check to see if trim is needed
+                //    var trim = true;
+                //    for (var i = 0; i < MAC_BYTES - 1; i++)
+                //    {
+                //        if (cipherText[i] != 0)
+                //        {
+                //            trim = false;
+                //            break;
+                //        }
+                //    }
+
+                //    //if the leading MAC_BYTES are null, trim it off before going on.
+                //    if (trim)
+                //    {
+                //        var temp = new byte[cipherText.Length - MAC_BYTES];
+                //        Array.Copy(cipherText, MAC_BYTES, temp, 0, cipherText.Length - MAC_BYTES);
+
+                //        cipherText = temp;
+                //    }
+                //}
+            }
+
+            var buffer = new byte[cipherText.Length - MAC_BYTES];
+            var ret = SodiumLibrary.crypto_secretbox_xchacha20poly1305_open_easy(buffer, cipherText, cipherText.Length, nonce, key);
+
+            if (ret != 0)
+                throw new CryptographicException("Failed to open SecretBox");
+
+            return buffer;
+        }
+
+
+        /// <summary>Opens a detached Secret Box using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="cipherText">Hex-encoded string to be opened</param>
+        /// <param name="mac">The 16 byte mac.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>The decrypted text.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="MacOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static byte[] Xchacha20Poly1305OpenDetached(string cipherText, byte[] mac, byte[] nonce, byte[] key) =>
+            Xchacha20Poly1305OpenDetached(Utilities.HexToBinary(cipherText), mac, nonce, key);
+
+        /// <summary>Opens a detached Secret Box using XChaCha20 and Poly1305 algorithms.</summary>
+        /// <param name="detached">A detached object.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>The decrypted text.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="MacOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static byte[] Xchacha20Poly1305OpenDetached(DetachedBox detached, byte[] nonce, byte[] key) =>
+            Xchacha20Poly1305OpenDetached(detached.CipherText, detached.Mac, nonce, key);
+
+        /// <summary>Opens a detached Secret Box</summary>
+        /// <param name="cipherText">The cipherText.</param>
+        /// <param name="mac">The 16 byte mac.</param>
+        /// <param name="nonce">The 24 byte nonce.</param>
+        /// <param name="key">The 32 byte key.</param>
+        /// <returns>The decrypted text.</returns>
+        /// <exception cref="KeyOutOfRangeException"></exception>
+        /// <exception cref="NonceOutOfRangeException"></exception>
+        /// <exception cref="MacOutOfRangeException"></exception>
+        /// <exception cref="CryptographicException"></exception>
+        public static byte[] Xchacha20Poly1305OpenDetached(byte[] cipherText, byte[] mac, byte[] nonce, byte[] key)
+        {
+            //validate the length of the key
+            if (key == null || key.Length != KEY_BYTES)
+                throw new KeyOutOfRangeException(nameof(key), (key == null) ? 0 : key.Length,
+                    $"key must be {KEY_BYTES} bytes in length.");
+
+            //validate the length of the nonce
+            if (nonce == null || nonce.Length != NONCE_BYTES)
+                throw new NonceOutOfRangeException(nameof(nonce), (nonce == null) ? 0 : nonce.Length,
+                    $"nonce must be {NONCE_BYTES} bytes in length.");
+
+            //validate the length of the mac
+            if (mac == null || mac.Length != MAC_BYTES)
+                throw new MacOutOfRangeException(nameof(mac), (mac == null) ? 0 : mac.Length,
+                    $"mac must be {MAC_BYTES} bytes in length.");
+
+            var buffer = new byte[cipherText.Length];
+            var ret = SodiumLibrary.crypto_secretbox_xchacha20poly1305_open_detached(buffer, cipherText, mac, cipherText.Length, nonce, key);
+
+            if (ret != 0)
+                throw new CryptographicException("Failed to open detached SecretBox");
+
+            return buffer;
+        }
+
     }
 }

--- a/src/Sodium.Core/SodiumLibrary.cs
+++ b/src/Sodium.Core/SodiumLibrary.cs
@@ -205,6 +205,22 @@ namespace Sodium
         //crypto_secretbox_open_detached
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int crypto_secretbox_open_detached(byte[] buffer, byte[] cipherText, byte[] mac, long cipherTextLength, byte[] nonce, byte[] key);
+        
+        //crypto_secretbox_xchacha20poly1305_easy
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int crypto_secretbox_xchacha20poly1305_easy(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] key);
+
+        //crypto_secretbox_xchacha20poly1305_open_easy
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int crypto_secretbox_xchacha20poly1305_open_easy(byte[] buffer, byte[] cipherText, long cipherTextLength, byte[] nonce, byte[] key);
+
+        //crypto_secretbox_xchacha20poly1305_detached
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int crypto_secretbox_xchacha20poly1305_detached(byte[] buffer, byte[] mac, byte[] message, long messageLength, byte[] nonce, byte[] key);
+
+        //crypto_secretbox_xchacha20poly1305_open_detached
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int crypto_secretbox_xchacha20poly1305_open_detached(byte[] buffer, byte[] cipherText, byte[] mac, long cipherTextLength, byte[] nonce, byte[] key);
 
         //crypto_auth
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]

--- a/test/Sodium.Tests/SecretBoxTest.cs
+++ b/test/Sodium.Tests/SecretBoxTest.cs
@@ -79,5 +79,62 @@ namespace Tests
 
             Assert.AreEqual(clear, expected);
         }
+
+        /// <summary>Does SecretBox.Create() return the expected value?</summary>
+        [Test]
+        public void Xchacha20Poly1305CreateSecretBox()
+        {
+            var expected = Utilities.HexToBinary("3bc2fce4a5a78ed04d5aadfcf5df9ad415792227a0c1ba79b87fd165");
+            var actual = SecretBox.Xchacha20Poly1305Create(
+              Encoding.UTF8.GetBytes("Adam Caudill"),
+              Encoding.UTF8.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWX"),
+              Encoding.UTF8.GetBytes("12345678901234567890123456789012"));
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        /// <summary>Does SecretBox.Xchacha20Poly1305Open() return the expected value?</summary>
+        [Test]
+        public void Xchacha20Poly1305OpenSecretBox()
+        {
+            const string EXPECTED = "Adam Caudill";
+            var actual = Encoding.UTF8.GetString(SecretBox.Xchacha20Poly1305Open(
+              Utilities.HexToBinary("3bc2fce4a5a78ed04d5aadfcf5df9ad415792227a0c1ba79b87fd165"),
+              Encoding.UTF8.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWX"),
+              Encoding.UTF8.GetBytes("12345678901234567890123456789012")));
+
+            Assert.AreEqual(EXPECTED, actual);
+        }
+
+        ///// <summary>Does SecretBox.Xchacha20Poly1305Open() return the expected value?</summary>
+        //[Test]
+        //public void Xchacha20Poly1305OpenSecretBoxWithPadding()
+        //{
+        //    // todo - please review this! i'm not sure if this test is needed also for xchacha-version
+
+        //    const string EXPECTED = "Adam Caudill";
+        //    var actual = Encoding.UTF8.GetString(SecretBox.Xchacha20Poly1305Open(
+        //        Utilities.HexToBinary("00000000000000000000000000000000b58d3c3e5ae78770b7db54e29e3885138a2f1ddb738f2309d9b38164"),
+        //        Encoding.UTF8.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWX"),
+        //        Encoding.UTF8.GetBytes("12345678901234567890123456789012")));
+
+        //    Assert.AreEqual(EXPECTED, actual);
+        //}
+
+        /// <summary>Does SecretBox.CreateDetached() and SecretBox.OpenDetached() work?</summary>
+        [Test]
+        public void Xchacha20Poly1305DetachedSecretBox()
+        {
+            var nonce = Encoding.UTF8.GetBytes("ABCDEFGHIJKLMNOPQRSTUVWX");
+            var key = Encoding.UTF8.GetBytes("12345678901234567890123456789012");
+            const string originalMessage = "Adam Caudill";
+
+            var detachedBox = SecretBox.Xchacha20Poly1305CreateDetached(Encoding.UTF8.GetBytes(originalMessage), nonce, key);
+
+            var decryptedMessage = Encoding.UTF8.GetString(
+                SecretBox.Xchacha20Poly1305OpenDetached(detachedBox.CipherText, detachedBox.Mac, nonce, key));
+
+            Assert.AreEqual(originalMessage, decryptedMessage);
+        }
     }
 }


### PR DESCRIPTION
Original **libsodium** library supports **XChaCha20+Poly1305** algorithm for **SecretBox** processing. It would be nice to add this feature to **Sodium.Core** also; and it's rather easy to do so because requres only trivial wrapping. 
So, then a user would have an **option** to choose between the default algorithm (XSalsa20+Poly1305) and **XChaCha20+Poly1305** algorithm:
![2020-09-21 03-02-20 Screenshot (2)](https://user-images.githubusercontent.com/17494479/93768765-8a717380-fc22-11ea-81d0-47d6a6efd583.png)

Please review the suggeted changes, I expect no difficulties there. Though just please pay attention to two chunks marked with "todo" (you will definitely understand quickly the reason of my doubt; most likely, these chunks are just not needed for XChaCha20+Poly1305 therefore i've commented them out, and I will delete them completely after your confirmation).
So, I hope your review will not consume much of your time.

_(We would like to migrate from original library to Sodium.Core, but **we urgently need** the abovementioned functionality to do this)._
