### PR TITLE
Get interop working with Mono AOT

### DIFF
--- a/src/Interop/Interop.Core.cs
+++ b/src/Interop/Interop.Core.cs
@@ -5,11 +5,13 @@ internal static partial class Interop
 {
     internal static partial class Libsodium
     {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void SodiumMisuseHandlerDelegate();
+
         [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int sodium_init();
 
         [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int sodium_set_misuse_handler(
-            Action handler);
+        internal static extern int sodium_set_misuse_handler(SodiumMisuseHandlerDelegate handler);
     }
 }

--- a/src/Interop/Interop.projitems
+++ b/src/Interop/Interop.projitems
@@ -34,5 +34,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Stream.XSalsa20.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Utils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Version.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono\MonoPInvokeCallbackAttribute.cs" />
   </ItemGroup>
 </Project>

--- a/src/Interop/Mono/MonoPInvokeCallbackAttribute.cs
+++ b/src/Interop/Mono/MonoPInvokeCallbackAttribute.cs
@@ -1,0 +1,11 @@
+namespace AOT
+{
+    using System;
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public class MonoPInvokeCallbackAttribute : Attribute
+    {
+        private Type type;
+        public MonoPInvokeCallbackAttribute(Type t) { type = t; }
+    }
+}

--- a/src/Sodium.Core/SodiumCore.Initialization.cs
+++ b/src/Sodium.Core/SodiumCore.Initialization.cs
@@ -1,3 +1,4 @@
+using AOT;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -8,7 +9,7 @@ namespace Sodium
 {
     public static partial class SodiumCore
     {
-        private static readonly Action s_misuseHandler = new(InternalError);
+        private static readonly SodiumMisuseHandlerDelegate s_misuseHandler = InternalErrorCallback;
 
         private static int s_initialized;
 
@@ -58,7 +59,8 @@ namespace Sodium
             Interlocked.Exchange(ref s_initialized, 1);
         }
 
-        private static void InternalError()
+        [MonoPInvokeCallback(typeof(SodiumMisuseHandlerDelegate))]
+        private static void InternalErrorCallback()
         {
             throw new NotSupportedException("An internal error occurred.");
         }


### PR DESCRIPTION
Resolve #87

I'm still working through issues running this in .NET 6 WASM, but these changes at least let me touch the libsodium native code I compiled myself.

Current error when I try to use GenericHash.Hash:
> missing function: arc4random_buf