### PR TITLE
Enable XML documentaion file generation

### DIFF
--- a/src/Sodium.Core/PasswordHash.Argon.cs
+++ b/src/Sodium.Core/PasswordHash.Argon.cs
@@ -74,6 +74,7 @@ namespace Sodium
         /// <param name="opsLimit">Represents a maximum amount of computations to perform.</param>
         /// <param name="memLimit">Is the maximum amount of RAM that the function will use, in bytes.</param>
         /// <param name="outputLength">The length of the computed output array.</param>
+        /// <param name="alg">Argon Algorithm</param>
         /// <returns>Returns a byte array of the given size.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>

--- a/src/Sodium.Core/Sodium.Core.csproj
+++ b/src/Sodium.Core/Sodium.Core.csproj
@@ -6,6 +6,7 @@
     <Features>strict</Features>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Sodium.Core/Sodium.Core.csproj
+++ b/src/Sodium.Core/Sodium.Core.csproj
@@ -7,6 +7,8 @@
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--  Supress missing XML docs warnings  -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #56

Added GenerateDocumentationFile property to enable XML doc file generation.

Added a NoWarn for [CS1591](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1591) (Missing XML comment for publicly visible type or member 'Type_or_Member').

Added a missing parameter doc to resolve a related warning.